### PR TITLE
Implement model detection

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.{c,cpp,h}]
+indent_style = space
+indent_size = 4
+tab_width = 4

--- a/BrainLILODrv.cpp
+++ b/BrainLILODrv.cpp
@@ -30,7 +30,10 @@
  * THE SOFTWARE.
  *
  */
+#include <fstream>
+#include <regex>
 #include <stdint.h>
+#include <stdlib.h>
 #include <windows.h>
 
 #define FSNOTIFY_POWER_OFF 1
@@ -157,35 +160,82 @@ __attribute__((noreturn)) static DWORD EDNA2_callKernelEntryPoint()
     EDNA2_runPhysicalInvoker();
 }
 
+static void ShowMessage(std::string msg, std::string title, UINT typ)
+{
+    void *bufMsg;
+    void *bufTitle;
+    bufMsg = LocalAlloc(LPTR, msg.length() * sizeof(wchar_t));
+    bufTitle = LocalAlloc(LPTR, title.length() * sizeof(wchar_t));
+    mbstowcs((wchar_t *)bufMsg, msg.c_str(), msg.length());
+    mbstowcs((wchar_t *)bufTitle, title.c_str(), title.length());
+    MessageBox(NULL, (wchar_t *)bufMsg, (wchar_t *)bufTitle, typ);
+    LocalFree(bufMsg);
+    LocalFree(bufTitle);
+}
+
 static bool doLinux()
 {
-    TCHAR bootloaderFileName[128] = TEXT("\\Storage Card\\loader\\u-boot.bin");
-    HANDLE hFile;
-    wchar_t buf[256];
+    wchar_t wcbuf[256];
+    int i;
+
+    std::ifstream iVersion;
+    std::string line, model;
+    std::regex modelRe("[A-Z]{2}-[A-Z0-9]+");
+    std::smatch match;
+
+    std::string fn("\\Storage Card\\loader\\");
+    HANDLE hUBoot;
     DWORD wReadSize;
 
-    OutputDebugString(L"BrainLILO: Opening Bootloader file...");
-    hFile = CreateFile(bootloaderFileName, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    if (hFile == INVALID_HANDLE_VALUE)
+    for (i = 0; i < int(sizeof(wcbuf) / sizeof(wcbuf[0])); i++)
     {
-        OutputDebugString(L"Cant open bootloader");
+        wcbuf[i] = '\0';
+    }
+
+    iVersion.open("\\NAND\\version.txt");
+    while (getline(iVersion, line))
+    {
+        if (regex_search(line, match, modelRe))
+        {
+            model = match[0].str();
+            break;
+        }
+    }
+
+    if (model.length() == 0)
+    {
+        ShowMessage("Failed to match the model name", "BrainLILO", MB_ICONWARNING);
         return false;
     }
-    swprintf(buf, L"BrainLILO: Bootloader file handle 0x%08x\n", (int)(hFile));
-    OutputDebugString(buf);
 
-    FileSize = GetFileSize(hFile, NULL);
-    swprintf(buf, L"BrainLILO: Bootloader file size %d Byte\n", FileSize);
-    OutputDebugString(buf);
+    OutputDebugString(L"BrainLILO: Opening Bootloader file...");
+    fn += model + ".bin";
+
+    mbstowcs(wcbuf, fn.c_str(), fn.length());
+    hUBoot = CreateFile(wcbuf, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hUBoot == INVALID_HANDLE_VALUE)
+    {
+        OutputDebugString(L"Could not open the bootloader");
+        ShowMessage(std::string("Could not open the bootloader: ") + fn, std::string("BrainLILO"), MB_ICONWARNING);
+        return false;
+    }
+
+    swprintf(wcbuf, L"BrainLILO: Bootloader file handle 0x%08x\n", (int)(hUBoot));
+    OutputDebugString(wcbuf);
+
+    FileSize = GetFileSize(hUBoot, NULL);
+    swprintf(wcbuf, L"BrainLILO: Bootloader file size %d Byte\n", FileSize);
+    OutputDebugString(wcbuf);
 
     OutputDebugString(L"BrainLILO: Preloading bootloader to 0xa0000000...");
-    if (!ReadFile(hFile, (void *)0xa0000000, FileSize, &wReadSize, NULL))
+    if (!ReadFile(hUBoot, (void *)0xa0000000, FileSize, &wReadSize, NULL))
     {
-        OutputDebugString(L"Cant read bootloader");
+        OutputDebugString(L"Could not read the bootloader");
+        ShowMessage(std::string("Could not read the bootloader"), std::string("BrainLILO"), MB_ICONWARNING);
         return false;
     }
     OutputDebugString(L"BrainLILO: Bootloader copied! Closing file handle...");
-    CloseHandle(hFile);
+    CloseHandle(hUBoot);
 
     OutputDebugString(L"BrainLILO: Notifying power off to filesystems...");
     if (FileSystemPowerFunction)

--- a/BrainLILODrv.cpp
+++ b/BrainLILODrv.cpp
@@ -175,7 +175,7 @@ static void ShowMessage(std::string msg, std::string title, UINT typ)
 
 static bool doLinux()
 {
-    wchar_t wcbuf[256] = {};
+    wchar_t wcBuf[256] = {};
 
     std::ifstream iVersion;
     std::string line, model;
@@ -205,8 +205,8 @@ static bool doLinux()
     OutputDebugString(L"BrainLILO: Opening Bootloader file...");
     fn += model + ".bin";
 
-    mbstowcs(wcbuf, fn.c_str(), fn.length());
-    hUBoot = CreateFile(wcbuf, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    mbstowcs(wcBuf, fn.c_str(), fn.length());
+    hUBoot = CreateFile(wcBuf, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hUBoot == INVALID_HANDLE_VALUE)
     {
         OutputDebugString(L"Could not open the bootloader");
@@ -214,12 +214,12 @@ static bool doLinux()
         return false;
     }
 
-    swprintf(wcbuf, L"BrainLILO: Bootloader file handle 0x%08x\n", (int)(hUBoot));
-    OutputDebugString(wcbuf);
+    swprintf(wcBuf, L"BrainLILO: Bootloader file handle 0x%08x\n", (int)(hUBoot));
+    OutputDebugString(wcBuf);
 
     FileSize = GetFileSize(hUBoot, NULL);
-    swprintf(wcbuf, L"BrainLILO: Bootloader file size %d Byte\n", FileSize);
-    OutputDebugString(wcbuf);
+    swprintf(wcBuf, L"BrainLILO: Bootloader file size %d Byte\n", FileSize);
+    OutputDebugString(wcBuf);
 
     OutputDebugString(L"BrainLILO: Preloading bootloader to 0xa0000000...");
     if (!ReadFile(hUBoot, (void *)0xa0000000, FileSize, &wReadSize, NULL))

--- a/BrainLILODrv.cpp
+++ b/BrainLILODrv.cpp
@@ -175,8 +175,7 @@ static void ShowMessage(std::string msg, std::string title, UINT typ)
 
 static bool doLinux()
 {
-    wchar_t wcbuf[256];
-    int i;
+    wchar_t wcbuf[256] = {};
 
     std::ifstream iVersion;
     std::string line, model;
@@ -186,11 +185,6 @@ static bool doLinux()
     std::string fn("\\Storage Card\\loader\\");
     HANDLE hUBoot;
     DWORD wReadSize;
-
-    for (i = 0; i < int(sizeof(wcbuf) / sizeof(wcbuf[0])); i++)
-    {
-        wcbuf[i] = '\0';
-    }
 
     iVersion.open("\\NAND\\version.txt");
     while (getline(iVersion, line))

--- a/BrainLILODrv.cpp
+++ b/BrainLILODrv.cpp
@@ -210,7 +210,7 @@ static bool doLinux()
     if (hUBoot == INVALID_HANDLE_VALUE)
     {
         OutputDebugString(L"Could not open the bootloader");
-        ShowMessage(std::string("Could not open the bootloader: ") + fn, std::string("BrainLILO"), MB_ICONWARNING);
+        ShowMessage("Could not open the bootloader: " + fn, "BrainLILO", MB_ICONWARNING);
         return false;
     }
 
@@ -225,7 +225,7 @@ static bool doLinux()
     if (!ReadFile(hUBoot, (void *)0xa0000000, FileSize, &wReadSize, NULL))
     {
         OutputDebugString(L"Could not read the bootloader");
-        ShowMessage(std::string("Could not read the bootloader"), std::string("BrainLILO"), MB_ICONWARNING);
+        ShowMessage("Could not read the bootloader", "BrainLILO", MB_ICONWARNING);
         return false;
     }
     OutputDebugString(L"BrainLILO: Bootloader copied! Closing file handle...");

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ DLLFLAGS=-DEV_PLATFORM_WIN32 -DUNICODE -D_UNICODE -DEV_UNSAFE_SWPRINTF -mwin32 \
 DRVFLAGS= -DEV_PLATFORM_WIN32 -DUNICODE -D_UNICODE -DEV_UNSAFE_SWPRINTF -mwin32 \
 -O0 -mcpu=arm926ej-s -D_WIN32_WCE=0x600 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 \
 -D_FILE_OFFSET_BITS=64 -DNDEBUG -Wall -static \
- -Wl,--image-base,0x100000 \
- -nostdlib -lcoredll -shared
+ -Wl,--image-base,0x100000,--allow-multiple-definition \
+ -lcoredll -shared
 
 .PHONY:		all clean
 

--- a/bootloader.cpp
+++ b/bootloader.cpp
@@ -1,47 +1,6 @@
 // This file is in public domain.
 
-#include <algorithm>
-#include <tchar.h>
-#include <vector>
 #include <windows.h>
-
-#define MainWindowClassName L"SelectorMainWindowClass"
-
-#define DataTypeAlertError 0x1000
-#define DataTypeAlertInformation 0x1001
-#define DataTypeAlertWarning 0x1002
-
-static void showAlertWarning(LPCWSTR message, LPCWSTR title)
-{
-
-    HWND selectorMainWindow = FindWindow(MainWindowClassName, NULL);
-
-    if (!selectorMainWindow)
-    {
-        MessageBox(NULL, message, title, MB_ICONWARNING);
-        return;
-    }
-
-    wchar_t data[2048];
-    wcscpy(data, message);
-    data[wcslen(message)] = 0;
-    wcscpy(data + wcslen(message) + 1, title);
-
-    size_t dataLen = wcslen(message) + wcslen(title) + 1;
-
-    COPYDATASTRUCT info;
-    info.dwData = DataTypeAlertWarning;
-    info.cbData = dataLen * sizeof(wchar_t);
-
-    HGLOBAL global = GlobalAlloc(GPTR, info.cbData);
-    memcpy((LPVOID)global, data, info.cbData);
-
-    info.lpData = (LPVOID)global;
-
-    SendMessage(selectorMainWindow, WM_COPYDATA, NULL, (LPARAM)&info);
-
-    GlobalFree(global);
-}
 
 int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPTSTR lpCmd, int nShow)
 {

--- a/bootloader.cpp
+++ b/bootloader.cpp
@@ -48,12 +48,6 @@ int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPTSTR lpCmd, int nShow)
     HINSTANCE lib = LoadLibrary(L"BrainLILO");
     if (!lib)
     {
-        wchar_t buf[256];
-        swprintf(buf,
-                 L"Cannot perform a soft reset.\n"
-                 L"BrainLILO was not loaded (0x%08x).",
-                 GetLastError());
-        showAlertWarning(buf, L"Error");
         return 1;
     }
 
@@ -61,23 +55,11 @@ int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPTSTR lpCmd, int nShow)
     RKDoSoftResetProc RKDoSoftReset = (RKDoSoftResetProc)GetProcAddress(lib, L"RKDoSoftReset");
     if (!RKDoSoftReset)
     {
-        wchar_t buf[256];
-        swprintf(buf,
-                 L"Cannot perform a soft reset.\n"
-                 L"RKDoSoftReset not found (0x%08x).",
-                 GetLastError());
-        showAlertWarning(buf, L"Error");
         return 1;
     }
 
     if (!RKDoSoftReset())
     {
-        wchar_t buf[256];
-        swprintf(buf,
-                 L"Cannot perform a soft reset.\n"
-                 L"Operation failed (0x%08x).",
-                 GetLastError());
-        showAlertWarning(buf, L"Error");
         return 1;
     }
     return 0;


### PR DESCRIPTION
機種名の検知とそれに基づいたロードを実装しました。

### 追加・変更内容
 - version.txt を1行ずつ正規表現でマッチし、成功したらそれをファイルパスに当てはめて U-Boot を読むようにした
   - たとえば、version.txt に `ED-SH1` と記述されていた場合は `\Storage Card\loader\ED-SH1.bin` を読みに行く
 - libstdc++ をリンク可能にするため、`-nostdlib` を無効化し関数の多重定義を許可した
   - これは本来なら悪手だが、多重定義を見過ごしたいのは `DllMainCRTStartup` のみと限定的であり、実機での動作が確認できたため受け入れることにした
   - `-nostdlib` を保ったままで `-lstdc++` とするとリンクに失敗する・試行錯誤するも失敗
 - WinMain 内でダイアログを出さないようにし、その代わり doLinux 内でダイアログを出すようにした
   - 理由1: 失敗した具体的理由がわかるようにするため
   - 理由2: `MessageBox` を2回以上呼ぶとフリーズするため
 - `bootloader.cpp` を掃除した

   ```
   /opt/cegcc/lib/gcc/arm-mingw32ce/9.3.0/../../../../arm-mingw32ce/bin/ld: /tmp/ccywy2oP.o:BrainLILODrv.cpp:(.text+0xf78): multiple definition of `DllMainCRTStartup'; /opt/cegcc/lib/gcc/arm-mingw32ce/9.3.0/../../../../arm-mingw32ce/lib/dllcrt3.o:/home/runner/work/cegcc-build/cegcc-build/mingw/dllcrt1.c:60: first defined here
   ```