### PR TITLE
Move the license body to the LICENSE file

### DIFF
--- a/BrainLILO.cpp
+++ b/BrainLILO.cpp
@@ -1,36 +1,3 @@
-/*
- * BrainLILO
- * U-Boot loader for electric dictionary.
- *
- * Copyright (C) 2019 C. Shirasaka <holly_programmer@outlook.com>
- * based on
- ** ResetKitHelper
- ** Soft/hard reset the electronic dictionary.
- **
- ** Copyright (C) 2012 T. Kawada <tcppjp [ at ] gmail.com>
- *
- * This file is licensed in MIT license.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- */
-
 #define BRAINLILO_API extern "C" __declspec(dllexport)
 #include "BrainLILO.h"
 #include "BrainLILODrv.h"

--- a/BrainLILO.h
+++ b/BrainLILO.h
@@ -1,5 +1,3 @@
-// This file is in public domain.
-
 #pragma once
 
 #include <windows.h>

--- a/BrainLILODrv.cpp
+++ b/BrainLILODrv.cpp
@@ -1,35 +1,3 @@
-/*
- * BrainLILODrv
- * U-Boot loader for electric dictionary.
- *
- * Copyright (C) 2019 C. Shirasaka <holly_programmer@outlook.com>
- * based on
- ** ResetKitHelper
- ** Soft/hard reset the electronic dictionary.
- **
- ** Copyright (C) 2012 T. Kawada <tcppjp [ at ] gmail.com>
- *
- * This file is licensed in MIT license.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- */
 #include <fstream>
 #include <regex>
 #include <stdint.h>

--- a/BrainLILODrv.h
+++ b/BrainLILODrv.h
@@ -1,5 +1,3 @@
-// This file is in public domain.
-
 #pragma once
 #include <winioctl.h>
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+*** BrainLILO ***
+
+MIT License
+
+Copyright (C) 2019 C. Shirasaka <holly_programmer@outlook.com>
+Copyright (C) 2012 T. Kawada <tcppjp [ at ] gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+BrainLILO.h, BrainLILODrv.h, and bootloader.cpp are in the public domain.

--- a/bootloader.cpp
+++ b/bootloader.cpp
@@ -1,5 +1,3 @@
-// This file is in public domain.
-
 #include <windows.h>
 
 int APIENTRY WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPTSTR lpCmd, int nShow)


### PR DESCRIPTION
This change makes it easier to copy the license agreement and the copyright notice from outside.